### PR TITLE
Feature/config gen improvements

### DIFF
--- a/.github/workflows/deploy-keeper.yml
+++ b/.github/workflows/deploy-keeper.yml
@@ -36,6 +36,7 @@ jobs:
           echo DISTRIBUTOR_PROCESS_INTERVAL=2000 >> .env
           echo MAX_ORDER_EXEC_ATTEMPTS=20 >> .env
           echo LOG_LEVEL=info >> .env
+          echo SIGNER_POOL_SIZE=4 >> .env
         if: github.ref == 'refs/heads/master'
 
       - name: Create .env.staging file
@@ -52,6 +53,7 @@ jobs:
           echo DISTRIBUTOR_PROCESS_INTERVAL=3000 >> .env.staging
           echo MAX_ORDER_EXEC_ATTEMPTS=20 >> .env.staging
           echo LOG_LEVEL=info >> .env.staging
+          echo SIGNER_POOL_SIZE=4 >> .env.staging
         if: github.ref == 'refs/heads/develop'
 
       - name: Deploy

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Variables for configuration are defined as environment variables. During develop
 | `PROVIDER_API_KEY_ALCHEMY`     | No       | An optional Alchemy RPC API key to fallback if Infura falls key    |                 |
 | `NETWORK`                      | No       | Network to keep against (goerli-ovm, mainnet-ovm)                  | optimism-goerli |
 | `FROM_BLOCK`                   | No       | Default block to index from                                        | 1               |
+| `SIGNER_POOL_SIZE`             | No       | Number of accounts from ETH_HD_WALLET to use as signers            | 1               |
 | `DISTRIBUTOR_PROCESS_INTERVAL` | No       | Number of ms to wait before processing the next batch of blocks    | 3000            |
 | `MAX_ORDER_EXEC_ATTEMPTS`      | No       | Maximum number of order execution attempst to try before ignoring  | 10              |
 | `METRICS_ENABLED`              | No       | Metrics enabled/disabled (1 = enabled, everything else = disabled) | 0               |

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ export const DEFAULT_CONFIG = {
   maxOrderExecAttempts: 10,
   isMetricsEnabled: false,
   distributorProcessInterval: 3000,
+  signerPoolSize: 1,
 };
 
 export const KeeperConfigSchema = z.object({
@@ -18,6 +19,11 @@ export const KeeperConfigSchema = z.object({
     .number()
     .positive()
     .default(DEFAULT_CONFIG.distributorProcessInterval),
+  signerPoolSize: z.coerce
+    .number()
+    .positive()
+    .min(1)
+    .default(DEFAULT_CONFIG.signerPoolSize),
   providerApiKeys: z.object({
     infura: z.string().min(1),
     alchemy: z.string().optional(),
@@ -48,6 +54,7 @@ export const getConfig = (force = false): KeeperConfig => {
 
   const result = KeeperConfigSchema.safeParse({
     fromBlock: process.env.FROM_BLOCK,
+    signerPoolSize: process.env.SIGNER_POOL_SIZE,
     providerApiKeys: {
       infura: process.env.PROVIDER_API_KEY_INFURA,
       alchemy: process.env.PROVIDER_API_KEY_ALCHEMY,

--- a/src/distributor.ts
+++ b/src/distributor.ts
@@ -1,5 +1,4 @@
 import { Contract, providers, Event, utils } from 'ethers';
-import { NonceManager } from '@ethersproject/experimental';
 import { Logger } from 'winston';
 import { getEvents } from './keepers/helpers';
 import { Keeper } from './keepers';

--- a/src/distributor.ts
+++ b/src/distributor.ts
@@ -6,7 +6,6 @@ import { Keeper } from './keepers';
 import { createLogger } from './logging';
 import { PerpsEvent } from './typed';
 import { Metric, Metrics } from './metrics';
-import { wei } from '@synthetixio/wei';
 import { uniq } from 'lodash';
 import { delay } from './utils';
 
@@ -25,7 +24,6 @@ export class Distributor {
     protected readonly baseAsset: string,
     private readonly provider: providers.BaseProvider,
     private readonly metrics: Metrics,
-    private readonly signer: NonceManager,
     private readonly fromBlock: number,
     private readonly distributorProcessInterval: number
   ) {
@@ -115,14 +113,12 @@ export class Distributor {
   async healthcheck(): Promise<void> {
     try {
       const uptime = Date.now() - this.START_TIME;
-      const balance = wei(await this.signer.getBalance()).toNumber();
-      this.logger.info('Performing keeper healthcheck', { args: { uptime, balance } });
+      this.logger.info('Performing keeper healthcheck', { args: { uptime } });
 
       // A failure to submit metric should not cause application to halt. Instead, alerts will pick this up if it happens
       // for a long enough duration. Essentially, do _not_ force keeper to slowdown operation just to track metrics
       // for offline usage/monitoring.
       this.metrics.time(Metric.KEEPER_UPTIME, uptime);
-      this.metrics.send(Metric.KEEPER_ETH_BALANCE, balance);
     } catch (err) {
       // NOTE: We do _not_ rethrow because healthchecks aren't `await` wrapped.
       this.logger.error('Distributor healthcheck failed', err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export const SIGNER_POOL_SIZE = 2;
 export const getProvider = async (
   config: KeeperConfig['providerApiKeys'],
   network: Network
-): Promise<providers.BaseProvider> => {
+): Promise<providers.FallbackProvider> => {
   // Infura has the highest priority (indicated by the lowest priority number).
   const providersConfig: providers.FallbackProviderConfig[] = [
     {
@@ -54,6 +54,8 @@ export const getProvider = async (
       weight: PROVIDER_DEFAULT_WEIGHT,
     });
   }
+
+  // @see: https://docs.ethers.org/v5/api/providers/other/#FallbackProvider
   return new providers.FallbackProvider(providersConfig);
 };
 
@@ -64,7 +66,7 @@ export const run = async (config: KeeperConfig) => {
   const provider = await getProvider(config.providerApiKeys, config.network);
   const latestBlock = await provider.getBlock('latest');
 
-  logger.info('Connected to OVM/EVM node', {
+  logger.info('Connected to node', {
     args: {
       network: config.network,
       latestBlockNumber: latestBlock.number,
@@ -83,7 +85,7 @@ export const run = async (config: KeeperConfig) => {
   );
 
   const marketKeys = Object.keys(markets);
-  logger.info('Creating XXX_Keeper per available market', {
+  logger.info('Creating n keeper(s) per kept market...', {
     args: { n: marketKeys.length },
   });
   for (const marketKey of marketKeys) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,6 @@ export const run = async (config: KeeperConfig) => {
       baseAsset,
       provider,
       metrics,
-      signer,
       config.fromBlock,
       config.distributorProcessInterval
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,9 +29,6 @@ const logger = createLogger('Application');
 export const PROVIDER_STALL_TIMEOUT = 750;
 export const PROVIDER_DEFAULT_WEIGHT = 1;
 
-// TODO: Pull this into an environment variable later.
-export const SIGNER_POOL_SIZE = 2;
-
 export const getProvider = async (
   config: KeeperConfig['providerApiKeys'],
   network: Network
@@ -74,7 +71,7 @@ export const run = async (config: KeeperConfig) => {
     },
   });
 
-  const signers = createSigners(config.ethHdwalletMnemonic, provider, SIGNER_POOL_SIZE);
+  const signers = createSigners(config.ethHdwalletMnemonic, provider, config.signerPoolSize);
   const signer = signers[0]; // There will always be at least 1.
   const signerPool = new SignerPool(signers);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ export const run = async (config: KeeperConfig) => {
 
   const signers = createSigners(config.ethHdwalletMnemonic, provider, config.signerPoolSize);
   const signer = signers[0]; // There will always be at least 1.
-  const signerPool = new SignerPool(signers);
+  const signerPool = new SignerPool(signers, metrics);
 
   const { markets, pyth, marketSettings, exchangeRates } = await getSynthetixPerpsContracts(
     config.network,

--- a/src/keepers/delayedOrders.ts
+++ b/src/keepers/delayedOrders.ts
@@ -137,7 +137,6 @@ export class DelayedOrdersKeeper extends Keeper {
     } catch (err) {
       order.executionFailures += 1;
       this.metrics.count(Metric.KEEPER_ERROR, this.metricDimensions);
-      throw err;
     }
   }
 

--- a/src/keepers/liquidation.ts
+++ b/src/keepers/liquidation.ts
@@ -171,11 +171,11 @@ export class LiquidationKeeper extends Keeper {
         },
         { asset: this.baseAsset }
       );
+      this.metrics.count(Metric.POSITION_LIQUIDATED, this.metricDimensions);
     } catch (err) {
       this.metrics.count(Metric.KEEPER_ERROR, this.metricDimensions);
       throw err;
     }
-    this.metrics.count(Metric.POSITION_LIQUIDATED, this.metricDimensions);
   }
 
   async execute(): Promise<void> {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -37,6 +37,9 @@ export enum Metric {
   // Open position liquidated successfully.
   POSITION_LIQUIDATED = 'PositionLiquidated',
 
+  // Number of available signers in the signer pool (0 means transactions cannot be executed).
+  SIGNER_POOL_SIZE = 'SignerPoolSize',
+
   // TODO: Add metrics for time taken per keeper type.
 }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -17,9 +17,6 @@ export enum Metric {
   // A metric sent upon startup (useful to track freq of crash & restarts).
   KEEPER_STARTUP = 'KeeperStartUp',
 
-  // Amount of ETH in the keeper address.
-  KEEPER_ETH_BALANCE = 'KeeperEthBalance',
-
   // When any error (liquidation or order execution) occurs.
   KEEPER_ERROR = 'KeeperError',
 

--- a/src/signerpool.ts
+++ b/src/signerpool.ts
@@ -80,7 +80,7 @@ export class SignerPool {
         // Special handling for NONCE_EXPIRED
         if (err.code === 'NONCE_EXPIRED') {
           this.logger.error(err.toString());
-          const nonce = signer.getTransactionCount('latest');
+          const nonce = await signer.getTransactionCount('latest');
           this.logger.info(`[${ctx.asset}] Updating nonce for Nonce manager to nonce: '${nonce}'`);
           signer.setTransactionCount(nonce);
         }

--- a/src/signerpool.ts
+++ b/src/signerpool.ts
@@ -51,21 +51,21 @@ export class SignerPool {
   }
 
   private async acquire(ctx: WithSignerContext): Promise<[number, NonceManager]> {
-    this.logger.info(`[${ctx.asset}] Awaiting signer...`);
-    let i = this.pool.pop();
+    this.logger.info(`[${ctx.asset}] Awaiting signer...`, { pool: this.pool });
+    let i = this.pool.shift();
 
     while (i === undefined) {
       await delay(this.ACQUIRE_SIGNER_DELAY);
-      i = this.pool.pop();
+      i = this.pool.shift();
     }
 
-    this.logger.info(`[${ctx.asset}] Acquired signer i=${i}, s=${this.pool.join(',')}`);
+    this.logger.info(`[${ctx.asset}] Acquired signer index '${i}'`, { pool: this.pool });
     return [i, this.signers[i]];
   }
 
   private release(i: number, ctx: WithSignerContext) {
     this.pool.push(i);
-    this.logger.info(`[${ctx.asset}] Released signer i=${i}, s=${this.pool.join(',')}`);
+    this.logger.info(`[${ctx.asset}] Released signer '${i}'`, { pool: this.pool });
   }
 
   async withSigner(

--- a/src/signerpool.ts
+++ b/src/signerpool.ts
@@ -47,11 +47,15 @@ export class SignerPool {
     this.pool = Array.from(Array(this.signers.length).keys());
     this.logger = logger;
 
-    this.logger.info(`Initialized pool s=${this.pool.join(',')}`);
+    this.logger.info('Initialized signer pool', { args: this.getLogArgs() });
+  }
+
+  private getLogArgs(): Record<string, string | number> {
+    return { pool: this.pool.join(','), n: this.pool.length };
   }
 
   private async acquire(ctx: WithSignerContext): Promise<[number, NonceManager]> {
-    this.logger.info(`[${ctx.asset}] Awaiting signer...`, { pool: this.pool });
+    this.logger.info(`[${ctx.asset}] Awaiting signer...`, { args: this.getLogArgs() });
     let i = this.pool.shift();
 
     while (i === undefined) {
@@ -59,13 +63,13 @@ export class SignerPool {
       i = this.pool.shift();
     }
 
-    this.logger.info(`[${ctx.asset}] Acquired signer index '${i}'`, { pool: this.pool });
+    this.logger.info(`[${ctx.asset}] Acquired signer index '${i}'`, { args: this.getLogArgs() });
     return [i, this.signers[i]];
   }
 
   private release(i: number, ctx: WithSignerContext) {
     this.pool.push(i);
-    this.logger.info(`[${ctx.asset}] Released signer '${i}'`, { pool: this.pool });
+    this.logger.info(`[${ctx.asset}] Released signer '${i}'`, { args: this.getLogArgs() });
   }
 
   async withSigner(

--- a/src/signerpool.ts
+++ b/src/signerpool.ts
@@ -63,13 +63,13 @@ export class SignerPool {
       i = this.pool.shift();
     }
 
-    this.logger.info(`[${ctx.asset}] Acquired signer index '${i}'`, { args: this.getLogArgs() });
+    this.logger.info(`[${ctx.asset}] Acquired signer @ index '${i}'`, { args: this.getLogArgs() });
     return [i, this.signers[i]];
   }
 
   private release(i: number, ctx: WithSignerContext) {
     this.pool.push(i);
-    this.logger.info(`[${ctx.asset}] Released signer '${i}'`, { args: this.getLogArgs() });
+    this.logger.info(`[${ctx.asset}] Released signer @ index '${i}'`, { args: this.getLogArgs() });
   }
 
   async withSigner(


### PR DESCRIPTION
Minor improvements:

- `executeOrder` no longer throws an error, giving other parallel trx to have a chance to continue processing
- Removes the ETH balance RPC call 
- Pulled SIGNER_POOL_SIZE into env var and add 2 additional signers (total of 4 signers)
- SignerPool now operates in a round robin rather than always using one signer with the rest staying idle
- Adds SignerPool CW metrics