### PR TITLE
feat: Add gas minimisation changes to allow comm keepers to exec first

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -34,6 +34,9 @@ export enum Metric {
   // Delayed order executed successfully.
   DELAYED_ORDER_EXECUTED = 'DelayedOrderExecuted',
 
+  // Delayed order executed mid-processing (includes off/on chain).
+  DELAYED_ORDER_ALREADY_EXECUTED = 'DelayedOrderAlreadyExecuted',
+
   // Offchain order executed successfully.
   OFFCHAIN_ORDER_EXECUTED = 'OffchainOrderExecuted',
 


### PR DESCRIPTION
- Increases the amount of time to artificially add on `Date.now` before execution
- Add metrics "already executed" metric
- Perform a final check on whether order exists before execution