### PR TITLE
Catch flag errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "lodash": "4.17.21",
         "log-process-errors": "6.3.0",
         "pm2": "5.1.2",
-        "synthetix": "^2.85.0",
+        "synthetix": "github:synthetixio/synthetix#caph-release-v2.86.1",
         "winston": "3.7.2",
         "winston-cloudwatch": "4.0.1",
         "zod": "^3.20.2"
@@ -17845,9 +17845,9 @@
       "dev": true
     },
     "node_modules/synthetix": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/synthetix/-/synthetix-2.85.0.tgz",
-      "integrity": "sha512-rBKvnbeJ/OR08lpoEPglm1JzZ7ykS0KiVrKq6oEw78YtEVqhOj4Q1tlJLh4/2cyKrNp7L4i4NSQG6FvL7NBXsA==",
+      "version": "2.86.0-alpha",
+      "resolved": "git+ssh://git@github.com/synthetixio/synthetix.git#49c150d8b7d6a9c3232ada9f0aa7af9d3428dc48",
+      "license": "MIT",
       "dependencies": {
         "@nomiclabs/hardhat-etherscan": "^3.1.0",
         "abi-decoder": "^2.3.0",
@@ -34029,9 +34029,8 @@
       "dev": true
     },
     "synthetix": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/synthetix/-/synthetix-2.85.0.tgz",
-      "integrity": "sha512-rBKvnbeJ/OR08lpoEPglm1JzZ7ykS0KiVrKq6oEw78YtEVqhOj4Q1tlJLh4/2cyKrNp7L4i4NSQG6FvL7NBXsA==",
+      "version": "git+ssh://git@github.com/synthetixio/synthetix.git#49c150d8b7d6a9c3232ada9f0aa7af9d3428dc48",
+      "from": "synthetix@github:synthetixio/synthetix#caph-release-v2.86.1",
       "requires": {
         "@nomiclabs/hardhat-etherscan": "^3.1.0",
         "abi-decoder": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lodash": "4.17.21",
     "log-process-errors": "6.3.0",
     "pm2": "5.1.2",
-    "synthetix": "^2.85.0",
+    "synthetix": "github:synthetixio/synthetix#caph-release-v2.86.1",
     "winston": "3.7.2",
     "winston-cloudwatch": "4.0.1",
     "zod": "^3.20.2"


### PR DESCRIPTION
- Catch flag errors to make sure we try to liquidate when flagging fails on old markets.
- Also update synthetix to get the new FuturesMarketManager. Using github branch since no npm release has been made